### PR TITLE
feat: Install shorebird flutter as part of the shorebird install.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,14 +13,14 @@ add_shorebird_to_path() {
   # Check if using zsh
   if [ -z "${ZSH_VERSION}" ]; then
     echo "Updating ~/.zshrc"
-    echo "export PATH=\"$(install_dir)/bin:\$PATH\"" >>~/.zshrc
+    echo "export PATH=\"$(install_dir)/shorebird/bin:\$PATH\"" >>~/.zshrc
   # Check if using bash
   elif [ -z "${BASH_VERSION}" ]; then
     echo "Updating ~/.bashrc"
-    echo "export PATH=\"$(install_dir)/bin:\$PATH\"" >>~/.bashrc
+    echo "export PATH=\"$(install_dir)/shorebird/bin:\$PATH\"" >>~/.bashrc
   else
     echo "Unable to determine shell type. Please add Shorebird to your PATH manually."
-    echo "export PATH=\"$(install_dir)/bin:\$PATH\""
+    echo "export PATH=\"$(install_dir)/shorebird/bin:\$PATH\""
   fi
 }
 
@@ -37,14 +37,17 @@ if ! hash git 2>/dev/null; then
 fi
 
 # Clone the Shorebird repository into the install_dir
-echo "Cloning Shorebird into $(install_dir)"
-git clone https://github.com/shorebirdtech/shorebird.git -b stable "$(install_dir)"
+echo "Cloning Shorebird into $(install_dir)/shorebird"
+git clone https://github.com/shorebirdtech/shorebird.git -b stable "$(install_dir)/shorebird"
+
+echo "Cloning Shorebird's Flutter into $(install_dir)/flutter"
+git clone --filter=tree:0 https://github.com/shorebirdtech/flutter.git -b stable "$(install_dir)/flutter"
 
 # Build Shorebird
-(cd "$(install_dir)" && ./bin/shorebird --version)
+(cd "$(install_dir)" && ./shorebird/bin/shorebird --version)
 
 RELOAD_REQUIRED=false
-SHOREBIRD_BIN="$(install_dir)/bin"
+SHOREBIRD_BIN="$(install_dir)/shorebird/bin"
 case :$PATH: in *:$SHOREBIRD_BIN:*) ;; # do nothing, it's there
 *)
   RELOAD_REQUIRED=true
@@ -59,7 +62,7 @@ if [ "$RELOAD_REQUIRED" = true ]; then
   echo "
 Close and reopen your terminal to start using Shorebird or run the following command to start using it now:
 
-  export PATH=\"$(install_dir)/bin:\$PATH\""
+  export PATH=\"$(install_dir)/shorebird/bin:\$PATH\""
 fi
 
 echo "


### PR DESCRIPTION
BREAKING CHANGE: this change alters the directory structure of the shorebird install. Users will need to reinstall shorebird after this change lands.

## Description

- Creates a [treeless clone](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/) of https://github.com/shorebirdtech/flutter during install
- Moves the shorebird install into a separate directory, installs flutter to `$INSTALL_ROOT/flutter` (e.g.,. `~/.shorebird/flutter).

Fixes https://github.com/shorebirdtech/shorebird/issues/221

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
