### PR TITLE
docs: Update docs link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,5 +69,5 @@ To get started, run the following command:
   shorebird --help
 
 For more information, visit:
-https://github.com/shorebirdtech/shorebird/blob/main/TRUSTED_TESTERS.md.
+https://docs.shorebird.dev/
 "


### PR DESCRIPTION
We use docs.shorebird.dev now.

The windows installer was already updated.