### PR TITLE
fix: lower minimum required git version

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -35,7 +35,7 @@ function Compare-GitVersions {
 }
 
 function Test-GitVersion {
-    $minGitVersion = "2.37.1"
+    $minGitVersion = "2.25.1"
     $gitVersion = (Get-Command git).FileVersionInfo.ProductVersion
 
     $comparisonResult = Compare-GitVersions -version1 $gitVersion -version2 $minGitVersion

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ if ! hash git 2>/dev/null; then
   exit 1
 fi
 
-MIN_GIT_VERSION="2.37.1"
+MIN_GIT_VERSION="2.25.1"
 GIT_VERSION=$(git --version | awk '{print $3}')
 set +e
 version_compare "$MIN_GIT_VERSION" "$GIT_VERSION"


### PR DESCRIPTION
## Description

CodeMagic users have reported that the minimum git version we set is too high. This change lowers it to what we've seen CodeMagic machines report.

Fixes https://github.com/shorebirdtech/shorebird/issues/893

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
