### PR TITLE
fix: update install.ps1 to exit on errors

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $installDirectory = [IO.Path]::Combine($home, ".shorebird")
 
 function Test-GitInstalled {


### PR DESCRIPTION
## Description

Use [`ErrorActionPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.3#erroractionpreference) to respond to errors by stopping script execution.

Fixes https://github.com/shorebirdtech/shorebird/issues/842

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
