### PR TITLE
Update install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -62,7 +62,7 @@ function Update-Path {
 Test-GitInstalled
 Test-GitVersion
 
-$force = $args -contains "--force"
+$force = $true
 
 if (Test-Path $installDirectory) {
     if ($force) {


### PR DESCRIPTION
An error occurs because of this line: $force = $args -contains "--force". When I execute the command on Windows, it displays the error: "Error: Existing Shorebird installation detected. Use --force to overwrite." But when i use --force then it show another error and shorebird is not install. However, upon removing this line and replacing it with $force = $true, I can install Shorebird successfully on Windows by copying and pasting the command into PowerShell.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
