### PR TITLE
feat: Checks needed disk space before starting install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -64,6 +64,20 @@ Test-GitVersion
 
 $force = $args -contains "--force"
 
+# Check if there is enough free space
+$requiredSpace = 1100MB # 1100 MiB
+$installDrive = (Split-Path -Qualifier $installDirectory).TrimEnd(':')
+$freeSpace = (Get-PSDrive -Name $installDrive).Free
+if ($freeSpace -lt $requiredSpace) {
+    if ($force) {
+        Write-Output "Attempting Shorebird install with less than 1100 MiB of free space."
+    }
+    else {
+        Write-Output "Error: Not enough free space. At least 1100 MiB is required. Use --force to install anyway."
+        exit 1
+    }
+}
+
 if (Test-Path $installDirectory) {
     if ($force) {
         Write-Output "Existing Shorebird installation detected. Overwriting..."

--- a/install.ps1
+++ b/install.ps1
@@ -65,9 +65,9 @@ Test-GitVersion
 $force = $args -contains "--force"
 
 # Check if there is enough free space
-$requiredSpace = 1100MB # 1100 MiB
-$installDrive = (Split-Path -Qualifier $installDirectory).TrimEnd(':')
-$freeSpace = (Get-PSDrive -Name $installDrive).Free
+$requiredSpace = 1100MB # 1100 MiB as bytes
+$installDrive = (Split-Path -Qualifier $installDirectory).TrimEnd(':') # Drive letter install directory
+$freeSpace = (Get-PSDrive -Name $installDrive).Free # Free space in bytes
 if ($freeSpace -lt $requiredSpace) {
     if ($force) {
         Write-Output "Attempting Shorebird install with less than 1100 MiB of free space."

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,18 @@ if [ $GIT_VERSION_COMPARISON -eq 2 ]; then
   exit 1
 fi
 
+# Check if there is enough free space
+REQUIRED_SPACE=$((1100 * 1024)) # 1100 MiB in KiB
+FREE_SPACE=$(df -k "$(dirname "$(install_dir)")" | tail -1 | awk '{print $4}')
+if [ $FREE_SPACE -lt $REQUIRED_SPACE ]; then
+  if [ "$FORCE" = true ]; then
+    echo "Attempting Shorebird install with less than 1100 MiB of free space."
+  else
+    echo >&2 "Error: Not enough free space. At least 1100 MiB is required. Use --force to install anyway."
+    exit 1
+  fi
+fi
+
 # Check if install_dir already exists
 if [ -d "$(install_dir)" ]; then
   if [ "$FORCE" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,8 @@ fi
 
 # Check if there is enough free space
 REQUIRED_SPACE=$((1100 * 1024)) # 1100 MiB in KiB
-FREE_SPACE=$(df -k "$(dirname "$(install_dir)")" | tail -1 | awk '{print $4}')
+INSTALL_VOLUME="$(dirname "$(install_dir)")" # Location of the install directory
+FREE_SPACE=$(df -k $INSTALL_VOLUME | tail -1 | awk '{print $4}') # Free space in KiB
 if [ $FREE_SPACE -lt $REQUIRED_SPACE ]; then
   if [ "$FORCE" = true ]; then
     echo "Attempting Shorebird install with less than 1100 MiB of free space."


### PR DESCRIPTION
Exit early when their likely will not be enough disk space to install shorebird

## Description
- Sets baseline of 1100 MiB of disk space needed to preform the install
- Users can still force an install using `--force`

Attempt to address https://github.com/shorebirdtech/install/issues/27

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
